### PR TITLE
Harmonize persona targets

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -11,3 +11,4 @@ coverage:
         threshold: 1%
 ignore:
   - tests/**/*
+  - src/_gettsim_personas/de/**/*

--- a/src/_gettsim_personas/de/einkommensteuer_sozialabgaben/couple_1_child.py
+++ b/src/_gettsim_personas/de/einkommensteuer_sozialabgaben/couple_1_child.py
@@ -181,30 +181,20 @@ def kindergeld__p_id_empfänger() -> np.ndarray:
 
 # Target columns
 @persona_target_element()
-def einkommensteuer__betrag_y_sn() -> None:
-    return None
+def einkommensteuer__betrag_m_sn() -> None:
+    pass
 
 
 @persona_target_element()
-def sozialversicherung__pflege__beitrag__betrag_versicherter_y() -> None:
-    return None
+def solidaritätszuschlag__betrag_m_sn() -> None:
+    pass
 
 
 @persona_target_element()
-def sozialversicherung__kranken__beitrag__betrag_versicherter_y() -> None:
-    return None
+def sozialversicherung__beiträge_versicherter_m_hh() -> None:
+    pass
 
 
 @persona_target_element()
-def sozialversicherung__rente__beitrag__betrag_versicherter_y() -> None:
-    return None
-
-
-@persona_target_element()
-def sozialversicherung__arbeitslosen__beitrag__betrag_versicherter_y() -> None:
-    return None
-
-
-@persona_target_element()
-def kindergeld__betrag_y() -> None:
-    return None
+def kindergeld__betrag_m_hh() -> None:
+    pass

--- a/src/_gettsim_personas/de/gesetzliche_altersrente/couple_with_fixed_public_pension.py
+++ b/src/_gettsim_personas/de/gesetzliche_altersrente/couple_with_fixed_public_pension.py
@@ -212,25 +212,15 @@ def sozialversicherung__rente__jahr_renteneintritt(
 
 
 @persona_target_element()
-def einkommensteuer__betrag_y_sn() -> None:
+def einkommensteuer__betrag_m_sn() -> None:
     pass
 
 
 @persona_target_element()
-def sozialversicherung__kranken__beitrag__betrag_versicherter_y() -> None:
+def solidaritätszuschlag__betrag_m_sn() -> None:
     pass
 
 
 @persona_target_element()
-def sozialversicherung__pflege__beitrag__betrag_versicherter_y() -> None:
-    pass
-
-
-@persona_target_element()
-def sozialversicherung__rente__beitrag__betrag_versicherter_y() -> None:
-    pass
-
-
-@persona_target_element()
-def sozialversicherung__arbeitslosen__beitrag__betrag_versicherter_y() -> None:
+def sozialversicherung__beiträge_versicherter_m_hh() -> None:
     pass

--- a/src/_gettsim_personas/de/gesetzliche_altersrente/single_with_fixed_public_pension.py
+++ b/src/_gettsim_personas/de/gesetzliche_altersrente/single_with_fixed_public_pension.py
@@ -212,25 +212,15 @@ def sozialversicherung__rente__jahr_renteneintritt(
 
 
 @persona_target_element()
-def einkommensteuer__betrag_y_sn() -> None:
+def einkommensteuer__betrag_m_sn() -> None:
     pass
 
 
 @persona_target_element()
-def sozialversicherung__kranken__beitrag__betrag_versicherter_y() -> None:
+def solidaritätszuschlag__betrag_m_sn() -> None:
     pass
 
 
 @persona_target_element()
-def sozialversicherung__pflege__beitrag__betrag_versicherter_y() -> None:
-    pass
-
-
-@persona_target_element()
-def sozialversicherung__rente__beitrag__betrag_versicherter_y() -> None:
-    pass
-
-
-@persona_target_element()
-def sozialversicherung__arbeitslosen__beitrag__betrag_versicherter_y() -> None:
+def sozialversicherung__beiträge_versicherter_m_hh() -> None:
     pass

--- a/src/_gettsim_personas/de/grundsicherung_für_erwerbsfähige/couple_1_child.py
+++ b/src/_gettsim_personas/de/grundsicherung_für_erwerbsfähige/couple_1_child.py
@@ -335,11 +335,6 @@ def kinderzuschlag__betrag_m_bg() -> None:
     pass
 
 
-@persona_target_element(start_date="2005-01-01")
-def wohngeld__betrag_m_wthh() -> None:
-    pass
-
-
 @persona_target_element(start_date="2005-01-01", end_date="2022-12-31")
 def arbeitslosengeld_2__betrag_m_bg() -> None:
     pass
@@ -347,4 +342,9 @@ def arbeitslosengeld_2__betrag_m_bg() -> None:
 
 @persona_target_element(start_date="2023-01-01")
 def bürgergeld__betrag_m_bg() -> None:
+    pass
+
+
+@persona_target_element(start_date="2005-01-01")
+def wohngeld__betrag_m_wthh() -> None:
     pass

--- a/src/_gettsim_personas/de/grundsicherung_für_erwerbsfähige/couple_1_child.py
+++ b/src/_gettsim_personas/de/grundsicherung_für_erwerbsfähige/couple_1_child.py
@@ -316,27 +316,27 @@ def einkommensteuer__betrag_m_sn() -> None:
 
 
 @persona_target_element(start_date="2005-01-01")
-def sozialversicherung__rente__beitrag__betrag_versicherter_y() -> None:
+def solidaritätszuschlag__betrag_m_sn() -> None:
     pass
 
 
 @persona_target_element(start_date="2005-01-01")
-def sozialversicherung__kranken__beitrag__betrag_versicherter_y() -> None:
+def sozialversicherung__beiträge_versicherter_m_hh() -> None:
     pass
 
 
 @persona_target_element(start_date="2005-01-01")
-def sozialversicherung__pflege__beitrag__betrag_versicherter_y() -> None:
+def kindergeld__betrag_m_hh() -> None:
     pass
 
 
 @persona_target_element(start_date="2005-01-01")
-def sozialversicherung__arbeitslosen__beitrag__betrag_versicherter_y() -> None:
+def kinderzuschlag__betrag_m_bg() -> None:
     pass
 
 
 @persona_target_element(start_date="2005-01-01")
-def sozialversicherung__arbeitslosen__betrag_m() -> None:
+def wohngeld__betrag_m_wthh() -> None:
     pass
 
 
@@ -347,19 +347,4 @@ def arbeitslosengeld_2__betrag_m_bg() -> None:
 
 @persona_target_element(start_date="2023-01-01")
 def bürgergeld__betrag_m_bg() -> None:
-    pass
-
-
-@persona_target_element(start_date="2005-01-01")
-def wohngeld__betrag_m_wthh() -> None:
-    pass
-
-
-@persona_target_element(start_date="2005-01-01")
-def kinderzuschlag__betrag_m_bg() -> None:
-    pass
-
-
-@persona_target_element(start_date="2005-01-01")
-def kindergeld__betrag_m() -> None:
     pass

--- a/src/_gettsim_personas/de/grundsicherung_für_erwerbsfähige/couple_1_child_in_karenzzeit.py
+++ b/src/_gettsim_personas/de/grundsicherung_für_erwerbsfähige/couple_1_child_in_karenzzeit.py
@@ -307,10 +307,10 @@ def kinderzuschlag__betrag_m_bg() -> None:
 
 
 @persona_target_element()
-def wohngeld__betrag_m_wthh() -> None:
+def bürgergeld__betrag_m_bg() -> None:
     pass
 
 
 @persona_target_element()
-def bürgergeld__betrag_m_bg() -> None:
+def wohngeld__betrag_m_wthh() -> None:
     pass

--- a/src/_gettsim_personas/de/grundsicherung_für_erwerbsfähige/couple_1_child_in_karenzzeit.py
+++ b/src/_gettsim_personas/de/grundsicherung_für_erwerbsfähige/couple_1_child_in_karenzzeit.py
@@ -287,37 +287,17 @@ def einkommensteuer__betrag_m_sn() -> None:
 
 
 @persona_target_element()
-def sozialversicherung__rente__beitrag__betrag_versicherter_y() -> None:
+def solidaritätszuschlag__betrag_m_sn() -> None:
     pass
 
 
 @persona_target_element()
-def sozialversicherung__kranken__beitrag__betrag_versicherter_y() -> None:
+def sozialversicherung__beiträge_versicherter_m_hh() -> None:
     pass
 
 
 @persona_target_element()
-def sozialversicherung__pflege__beitrag__betrag_versicherter_y() -> None:
-    pass
-
-
-@persona_target_element()
-def sozialversicherung__arbeitslosen__beitrag__betrag_versicherter_y() -> None:
-    pass
-
-
-@persona_target_element()
-def sozialversicherung__arbeitslosen__betrag_m() -> None:
-    pass
-
-
-@persona_target_element()
-def bürgergeld__betrag_m_bg() -> None:
-    pass
-
-
-@persona_target_element()
-def wohngeld__betrag_m_wthh() -> None:
+def kindergeld__betrag_m_hh() -> None:
     pass
 
 
@@ -327,5 +307,10 @@ def kinderzuschlag__betrag_m_bg() -> None:
 
 
 @persona_target_element()
-def kindergeld__betrag_m() -> None:
+def wohngeld__betrag_m_wthh() -> None:
+    pass
+
+
+@persona_target_element()
+def bürgergeld__betrag_m_bg() -> None:
     pass

--- a/src/_gettsim_personas/de/grundsicherung_für_erwerbsfähige/couple_2_children.py
+++ b/src/_gettsim_personas/de/grundsicherung_für_erwerbsfähige/couple_2_children.py
@@ -335,11 +335,6 @@ def kinderzuschlag__betrag_m_bg() -> None:
     pass
 
 
-@persona_target_element(start_date="2005-01-01")
-def wohngeld__betrag_m_wthh() -> None:
-    pass
-
-
 @persona_target_element(start_date="2005-01-01", end_date="2022-12-31")
 def arbeitslosengeld_2__betrag_m_bg() -> None:
     pass
@@ -347,4 +342,9 @@ def arbeitslosengeld_2__betrag_m_bg() -> None:
 
 @persona_target_element(start_date="2023-01-01")
 def bürgergeld__betrag_m_bg() -> None:
+    pass
+
+
+@persona_target_element(start_date="2005-01-01")
+def wohngeld__betrag_m_wthh() -> None:
     pass

--- a/src/_gettsim_personas/de/grundsicherung_für_erwerbsfähige/couple_2_children.py
+++ b/src/_gettsim_personas/de/grundsicherung_für_erwerbsfähige/couple_2_children.py
@@ -316,27 +316,27 @@ def einkommensteuer__betrag_m_sn() -> None:
 
 
 @persona_target_element(start_date="2005-01-01")
-def sozialversicherung__rente__beitrag__betrag_versicherter_y() -> None:
+def solidaritätszuschlag__betrag_m_sn() -> None:
     pass
 
 
 @persona_target_element(start_date="2005-01-01")
-def sozialversicherung__kranken__beitrag__betrag_versicherter_y() -> None:
+def sozialversicherung__beiträge_versicherter_m_hh() -> None:
     pass
 
 
 @persona_target_element(start_date="2005-01-01")
-def sozialversicherung__pflege__beitrag__betrag_versicherter_y() -> None:
+def kindergeld__betrag_m_hh() -> None:
     pass
 
 
 @persona_target_element(start_date="2005-01-01")
-def sozialversicherung__arbeitslosen__beitrag__betrag_versicherter_y() -> None:
+def kinderzuschlag__betrag_m_bg() -> None:
     pass
 
 
 @persona_target_element(start_date="2005-01-01")
-def sozialversicherung__arbeitslosen__betrag_m() -> None:
+def wohngeld__betrag_m_wthh() -> None:
     pass
 
 
@@ -347,19 +347,4 @@ def arbeitslosengeld_2__betrag_m_bg() -> None:
 
 @persona_target_element(start_date="2023-01-01")
 def bürgergeld__betrag_m_bg() -> None:
-    pass
-
-
-@persona_target_element(start_date="2005-01-01")
-def wohngeld__betrag_m_wthh() -> None:
-    pass
-
-
-@persona_target_element(start_date="2005-01-01")
-def kinderzuschlag__betrag_m_bg() -> None:
-    pass
-
-
-@persona_target_element(start_date="2005-01-01")
-def kindergeld__betrag_m() -> None:
     pass

--- a/src/_gettsim_personas/de/grundsicherung_für_erwerbsfähige/couple_no_children.py
+++ b/src/_gettsim_personas/de/grundsicherung_für_erwerbsfähige/couple_no_children.py
@@ -317,27 +317,27 @@ def einkommensteuer__betrag_m_sn() -> None:
 
 
 @persona_target_element(start_date="2005-01-01")
-def sozialversicherung__rente__beitrag__betrag_versicherter_y() -> None:
+def solidaritätszuschlag__betrag_m_sn() -> None:
     pass
 
 
 @persona_target_element(start_date="2005-01-01")
-def sozialversicherung__kranken__beitrag__betrag_versicherter_y() -> None:
+def sozialversicherung__beiträge_versicherter_m_hh() -> None:
     pass
 
 
 @persona_target_element(start_date="2005-01-01")
-def sozialversicherung__pflege__beitrag__betrag_versicherter_y() -> None:
+def kindergeld__betrag_m_hh() -> None:
     pass
 
 
 @persona_target_element(start_date="2005-01-01")
-def sozialversicherung__arbeitslosen__beitrag__betrag_versicherter_y() -> None:
+def kinderzuschlag__betrag_m_bg() -> None:
     pass
 
 
 @persona_target_element(start_date="2005-01-01")
-def sozialversicherung__arbeitslosen__betrag_m() -> None:
+def wohngeld__betrag_m_wthh() -> None:
     pass
 
 
@@ -348,9 +348,4 @@ def arbeitslosengeld_2__betrag_m_bg() -> None:
 
 @persona_target_element(start_date="2023-01-01")
 def bürgergeld__betrag_m_bg() -> None:
-    pass
-
-
-@persona_target_element(start_date="2005-01-01")
-def wohngeld__betrag_m_wthh() -> None:
     pass

--- a/src/_gettsim_personas/de/grundsicherung_für_erwerbsfähige/couple_no_children.py
+++ b/src/_gettsim_personas/de/grundsicherung_für_erwerbsfähige/couple_no_children.py
@@ -336,11 +336,6 @@ def kinderzuschlag__betrag_m_bg() -> None:
     pass
 
 
-@persona_target_element(start_date="2005-01-01")
-def wohngeld__betrag_m_wthh() -> None:
-    pass
-
-
 @persona_target_element(start_date="2005-01-01", end_date="2022-12-31")
 def arbeitslosengeld_2__betrag_m_bg() -> None:
     pass
@@ -348,4 +343,9 @@ def arbeitslosengeld_2__betrag_m_bg() -> None:
 
 @persona_target_element(start_date="2023-01-01")
 def bürgergeld__betrag_m_bg() -> None:
+    pass
+
+
+@persona_target_element(start_date="2005-01-01")
+def wohngeld__betrag_m_wthh() -> None:
     pass

--- a/src/_gettsim_personas/de/grundsicherung_für_erwerbsfähige/single_1_child.py
+++ b/src/_gettsim_personas/de/grundsicherung_für_erwerbsfähige/single_1_child.py
@@ -335,11 +335,6 @@ def kinderzuschlag__betrag_m_bg() -> None:
     pass
 
 
-@persona_target_element(start_date="2005-01-01")
-def wohngeld__betrag_m_wthh() -> None:
-    pass
-
-
 @persona_target_element(start_date="2005-01-01", end_date="2022-12-31")
 def arbeitslosengeld_2__betrag_m_bg() -> None:
     pass
@@ -347,4 +342,9 @@ def arbeitslosengeld_2__betrag_m_bg() -> None:
 
 @persona_target_element(start_date="2023-01-01")
 def bürgergeld__betrag_m_bg() -> None:
+    pass
+
+
+@persona_target_element(start_date="2005-01-01")
+def wohngeld__betrag_m_wthh() -> None:
     pass

--- a/src/_gettsim_personas/de/grundsicherung_für_erwerbsfähige/single_1_child.py
+++ b/src/_gettsim_personas/de/grundsicherung_für_erwerbsfähige/single_1_child.py
@@ -311,27 +311,32 @@ def einkommensteuer__betrag_m_sn() -> None:
 
 
 @persona_target_element(start_date="2005-01-01")
-def sozialversicherung__rente__beitrag__betrag_versicherter_y() -> None:
+def solidaritätszuschlag__betrag_m_sn() -> None:
     pass
 
 
 @persona_target_element(start_date="2005-01-01")
-def sozialversicherung__kranken__beitrag__betrag_versicherter_y() -> None:
+def sozialversicherung__beiträge_versicherter_m_hh() -> None:
     pass
 
 
 @persona_target_element(start_date="2005-01-01")
-def sozialversicherung__pflege__beitrag__betrag_versicherter_y() -> None:
+def kindergeld__betrag_m_hh() -> None:
     pass
 
 
 @persona_target_element(start_date="2005-01-01")
-def sozialversicherung__arbeitslosen__beitrag__betrag_versicherter_y() -> None:
+def unterhaltsvorschuss__betrag_m_hh() -> None:
     pass
 
 
 @persona_target_element(start_date="2005-01-01")
-def sozialversicherung__arbeitslosen__betrag_m() -> None:
+def kinderzuschlag__betrag_m_bg() -> None:
+    pass
+
+
+@persona_target_element(start_date="2005-01-01")
+def wohngeld__betrag_m_wthh() -> None:
     pass
 
 
@@ -342,24 +347,4 @@ def arbeitslosengeld_2__betrag_m_bg() -> None:
 
 @persona_target_element(start_date="2023-01-01")
 def bürgergeld__betrag_m_bg() -> None:
-    pass
-
-
-@persona_target_element(start_date="2005-01-01")
-def wohngeld__betrag_m_wthh() -> None:
-    pass
-
-
-@persona_target_element(start_date="2005-01-01")
-def kinderzuschlag__betrag_m_bg() -> None:
-    pass
-
-
-@persona_target_element(start_date="2005-01-01")
-def kindergeld__betrag_m() -> None:
-    pass
-
-
-@persona_target_element(start_date="2005-01-01")
-def unterhaltsvorschuss__betrag_m() -> None:
     pass

--- a/src/_gettsim_personas/de/grundsicherung_für_erwerbsfähige/single_adult.py
+++ b/src/_gettsim_personas/de/grundsicherung_für_erwerbsfähige/single_adult.py
@@ -311,45 +311,40 @@ def kindergeld__p_id_empfänger() -> np.ndarray:
 
 
 @persona_target_element()
-def einkommensteuer__betrag_y_sn() -> None:
-    return None
+def einkommensteuer__betrag_m_sn() -> None:
+    pass
 
 
 @persona_target_element()
-def sozialversicherung__pflege__beitrag__betrag_versicherter_y() -> None:
-    return None
+def solidaritätszuschlag__betrag_m_sn() -> None:
+    pass
 
 
 @persona_target_element()
-def sozialversicherung__kranken__beitrag__betrag_versicherter_y() -> None:
-    return None
+def sozialversicherung__beiträge_versicherter_m_hh() -> None:
+    pass
 
 
 @persona_target_element()
-def sozialversicherung__rente__beitrag__betrag_versicherter_y() -> None:
-    return None
+def kindergeld__betrag_m_hh() -> None:
+    pass
+
+
+@persona_target_element(start_date="2005-01-01")
+def kinderzuschlag__betrag_m_bg() -> None:
+    pass
 
 
 @persona_target_element()
-def sozialversicherung__arbeitslosen__beitrag__betrag_versicherter_y() -> None:
-    return None
-
-
-@persona_target_element()
-def sozialversicherung__arbeitslosen__betrag_y() -> None:
+def wohngeld__betrag_m_wthh() -> None:
     pass
 
 
 @persona_target_element(start_date="2005-01-01", end_date="2022-12-31")
-def arbeitslosengeld_2__betrag_y_bg() -> None:
+def arbeitslosengeld_2__betrag_m_bg() -> None:
     pass
 
 
 @persona_target_element(start_date="2023-01-01")
-def bürgergeld__betrag_y_bg() -> None:
-    pass
-
-
-@persona_target_element()
-def wohngeld__betrag_y_wthh() -> None:
+def bürgergeld__betrag_m_bg() -> None:
     pass

--- a/src/_gettsim_personas/de/grundsicherung_für_erwerbsfähige/single_adult.py
+++ b/src/_gettsim_personas/de/grundsicherung_für_erwerbsfähige/single_adult.py
@@ -335,11 +335,6 @@ def kinderzuschlag__betrag_m_bg() -> None:
     pass
 
 
-@persona_target_element()
-def wohngeld__betrag_m_wthh() -> None:
-    pass
-
-
 @persona_target_element(start_date="2005-01-01", end_date="2022-12-31")
 def arbeitslosengeld_2__betrag_m_bg() -> None:
     pass
@@ -347,4 +342,9 @@ def arbeitslosengeld_2__betrag_m_bg() -> None:
 
 @persona_target_element(start_date="2023-01-01")
 def bürgergeld__betrag_m_bg() -> None:
+    pass
+
+
+@persona_target_element()
+def wohngeld__betrag_m_wthh() -> None:
     pass

--- a/src/_gettsim_personas/de/grundsicherung_im_alter/couple_1_child.py
+++ b/src/_gettsim_personas/de/grundsicherung_im_alter/couple_1_child.py
@@ -303,17 +303,17 @@ def sozialversicherung__arbeitslosen__betrag_m() -> np.ndarray:
 
 
 @persona_target_element()
-def einkommensteuer__betrag_y_sn() -> None:
+def einkommensteuer__betrag_m_sn() -> None:
     pass
 
 
 @persona_target_element()
-def sozialversicherung__kranken__beitrag__betrag_versicherter_y() -> None:
+def solidaritätszuschlag__betrag_m_sn() -> None:
     pass
 
 
 @persona_target_element()
-def sozialversicherung__pflege__beitrag__betrag_versicherter_y() -> None:
+def sozialversicherung__beiträge_versicherter_m_hh() -> None:
     pass
 
 

--- a/src/_gettsim_personas/de/grundsicherung_im_alter/couple_no_child.py
+++ b/src/_gettsim_personas/de/grundsicherung_im_alter/couple_no_child.py
@@ -302,17 +302,17 @@ def sozialversicherung__arbeitslosen__betrag_m() -> np.ndarray:
 
 
 @persona_target_element()
-def einkommensteuer__betrag_y_sn() -> None:
+def einkommensteuer__betrag_m_sn() -> None:
     pass
 
 
 @persona_target_element()
-def sozialversicherung__kranken__beitrag__betrag_versicherter_y() -> None:
+def solidaritätszuschlag__betrag_m_sn() -> None:
     pass
 
 
 @persona_target_element()
-def sozialversicherung__pflege__beitrag__betrag_versicherter_y() -> None:
+def sozialversicherung__beiträge_versicherter_m_hh() -> None:
     pass
 
 

--- a/src/_gettsim_personas/de/grundsicherung_im_alter/single_1_child.py
+++ b/src/_gettsim_personas/de/grundsicherung_im_alter/single_1_child.py
@@ -302,17 +302,17 @@ def sozialversicherung__arbeitslosen__betrag_m() -> np.ndarray:
 
 
 @persona_target_element()
-def einkommensteuer__betrag_y_sn() -> None:
+def einkommensteuer__betrag_m_sn() -> None:
     pass
 
 
 @persona_target_element()
-def sozialversicherung__kranken__beitrag__betrag_versicherter_y() -> None:
+def solidaritätszuschlag__betrag_m_sn() -> None:
     pass
 
 
 @persona_target_element()
-def sozialversicherung__pflege__beitrag__betrag_versicherter_y() -> None:
+def sozialversicherung__beiträge_versicherter_m_hh() -> None:
     pass
 
 

--- a/src/_gettsim_personas/de/grundsicherung_im_alter/single_no_child.py
+++ b/src/_gettsim_personas/de/grundsicherung_im_alter/single_no_child.py
@@ -307,25 +307,25 @@ def sozialversicherung__arbeitslosen__betrag_m() -> np.ndarray:
 
 
 @persona_target_element()
-def einkommensteuer__betrag_y_sn() -> None:
+def einkommensteuer__betrag_m_sn() -> None:
     pass
 
 
 @persona_target_element()
-def sozialversicherung__kranken__beitrag__betrag_versicherter_y() -> None:
+def solidaritätszuschlag__betrag_m_sn() -> None:
     pass
 
 
 @persona_target_element()
-def sozialversicherung__pflege__beitrag__betrag_versicherter_y() -> None:
+def sozialversicherung__beiträge_versicherter_m_hh() -> None:
     pass
 
 
 @persona_target_element()
-def grundsicherung__im_alter__betrag_y_eg() -> None:
+def grundsicherung__im_alter__betrag_m_eg() -> None:
     pass
 
 
 @persona_target_element()
-def wohngeld__betrag_y_wthh() -> None:
+def wohngeld__betrag_m_wthh() -> None:
     pass


### PR DESCRIPTION
Harmonize targets across personas:
- Use `_m` instead of `_y`
- Use grouped targets
- Use `sozialversicherung__beitrag_arbeitnehmer_m_hh` instead of the 4 individual SozV Beiträge

Also we exclude persona definitions from codecov now.
