### PR TITLE
Adopt ty pre-commit hook; bump .ai-instructions to c2701d4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,9 +26,9 @@ jobs:
           cache: true
           cache-write: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
           frozen: true
-          environments: type-checking
+          environments: py314
       - name: Run ty
-        run: pixi run --locked -e type-checking ty
+        run: pixi run --locked -e py314 prek run ty --all-files
         shell: bash -el {0}
   run-tests:
     name: Run tests for ${{ matrix.os }} on ${{ matrix.environment }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -67,6 +67,15 @@ repos:
           - jupyter
           - pyi
           - python
+  - repo: https://github.com/astral-sh/ty-pre-commit
+    rev: v0.0.49
+    hooks:
+      - id: ty
+        # `--no-project` keeps uv from creating a `.venv`/`uv.lock` in this
+        # pixi-managed repo; ty resolves third-party imports from the env named
+        # in `[tool.ty] environment.python` (run `pixi install` once).
+        args:
+          - --no-project
   - repo: https://github.com/executablebooks/mdformat
     rev: 1.0.0
     hooks:
@@ -81,3 +90,7 @@ repos:
         files: (AGENTS\.md|CLAUDE\.md|README\.md|modules/.*\.md|profiles/.*\.md)
 ci:
   autoupdate_schedule: monthly
+  # pre-commit.ci has no pixi environments and blocks network at hook runtime;
+  # the GitHub Actions run-ty job covers type checking.
+  skip:
+    - ty

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,20 +24,19 @@ pixi run -e py314 tests -n 7          # parallel
 pixi run -e py314 tests -k "test_end_to_end"
 pixi run -e py314 tests tests/infrastructure/test_persona_objects.py
 
-# Type checking
-pixi run ty
+# Type checking (runs as the ty pre-commit hook)
+prek run ty --all-files
 
 # Quality checks
 pixi run prek run --all-files
 
-# Available environments: py311, py312, py313, py314, type-checking
+# Available environments: py311, py312, py313, py314
 ```
 
-Before finishing any task that modifies code, always run these three verification steps
-in order:
+Before finishing any task that modifies code, always run these two verification steps in
+order:
 
-1. `pixi run ty` (type checker)
-1. `pixi run prek run --all-files` (quality checks)
+1. `pixi run prek run --all-files` (quality checks incl. ty type checking)
 1. `pixi run -e py314 tests -n 7` (full test suite)
 
 ## Architecture

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,6 @@ py311 = [ "tests", "py311" ]
 py312 = [ "tests", "py312" ]
 py313 = [ "tests", "py313" ]
 py314 = [ "tests", "py314" ]
-type-checking = [ "py314", "type-checking" ]
 [tool.pixi.feature.py311.dependencies]
 python = "~=3.11.0"
 [tool.pixi.feature.py312.dependencies]
@@ -96,10 +95,6 @@ types-pytz = "*"
 [tool.pixi.feature.tests.tasks]
 tests = "pytest"
 tests-with-cov = "pytest --cov-report=xml --cov=./"
-[tool.pixi.feature.type-checking.pypi-dependencies]
-ty = "*"
-[tool.pixi.feature.type-checking.tasks]
-ty = "ty check"
 [tool.pixi.pypi-dependencies]
 gettsim_personas = { path = ".", editable = true }
 ttsim-backend = { git = "https://github.com/ttsim-dev/ttsim.git", branch = "main" }
@@ -157,14 +152,16 @@ expand_tables = [
   "tool.pixi.feature.tests.activation.env",
   "tool.pixi.feature.tests.pypi-dependencies",
   "tool.pixi.feature.tests.tasks",
-  "tool.pixi.feature.type-checking.pypi-dependencies",
-  "tool.pixi.feature.type-checking.tasks",
   "tool.pixi.pypi-dependencies",
   "tool.pixi.tasks",
   "tool.pixi.workspace",
 ]
 
 [tool.ty]
+# ty resolves third-party imports from this pixi env (the ty-pre-commit hook runs
+# `uv check --no-project`, so uv neither creates a `.venv` nor resolves deps). Run
+# `pixi install` once.
+environment.python = ".pixi/envs/py314"
 rules.ambiguous-protocol-member = "error"
 rules.deprecated = "error"
 rules.division-by-zero = "error"


### PR DESCRIPTION
Adopt the official `astral-sh/ty-pre-commit` hook (ty==0.0.49), checking against
`.pixi/envs/py314` via `[tool.ty] environment.python`. No jax backend here, so no
`ty-jax` hook.

- Remove the `type-checking` pixi env + feature (the old ty pin + type stubs).
- pre-commit.ci skips `ty`; the GHA `run-ty` job runs it via prek.
- AGENTS.md: ty now runs via `prek run --all-files`.
- Bump `.ai-instructions` to c2701d4 (real tiering, distilled modules,
  ty-pre-commit boilerplate).

Branched fresh off `main` (the `chore/kwarg-call-sweep` line is already merged via
#39), so this is a single clean commit. `prek run --all-files` passes, including `ty`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
